### PR TITLE
Deleted type SFVertexArray so that it can be defined in vertex_array.pony.

### DIFF
--- a/sfml/basic_types.pony
+++ b/sfml/basic_types.pony
@@ -120,18 +120,3 @@ struct SFVertex
         tex_y = tex_y'
 
 type SFVertexRaw is NullablePointer[SFVertex]
-
-primitive SFPrimitiveType
-    fun sfPoints() : I32 =>         0
-    fun sfLines() : I32 =>          1
-    fun sfLineStrip() : I32 =>      2
-    fun sfTriangles() : I32 =>      3
-    fun sfTriangleStrip() : I32 =>  4
-    fun sfTriangleFan() : I32 =>    5
-    fun sfQuads() : I32 =>          6
-    // Deprecated names
-    fun sfLinesStrip() : I32 =>     2
-    fun sfTrianglesStrip() : I32 => 4
-    fun sfTrianglesFan() : I32 =>   5
-
-type SFVertexArray is Array[SFVertex]

--- a/sfml/basic_types.pony
+++ b/sfml/basic_types.pony
@@ -120,3 +120,16 @@ struct SFVertex
         tex_y = tex_y'
 
 type SFVertexRaw is NullablePointer[SFVertex]
+
+primitive SFPrimitiveType
+    fun sfPoints() : I32 =>         0
+    fun sfLines() : I32 =>          1
+    fun sfLineStrip() : I32 =>      2
+    fun sfTriangles() : I32 =>      3
+    fun sfTriangleStrip() : I32 =>  4
+    fun sfTriangleFan() : I32 =>    5
+    fun sfQuads() : I32 =>          6
+    // Deprecated names
+    fun sfLinesStrip() : I32 =>     2
+    fun sfTrianglesStrip() : I32 => 4
+    fun sfTrianglesFan() : I32 =>   5


### PR DESCRIPTION
SFVertexArray can't be an alias of `Array[SFVertex]` because it is a SFML C++ class that has `PrimitiveType` state in addition to the vertices. I'm redefining it in vertex_array.pony, similar to your definition of text.pony.